### PR TITLE
import fann with prefix to reflect how it is being called

### DIFF
--- a/sample-mini-ocr.scm
+++ b/sample-mini-ocr.scm
@@ -1,4 +1,4 @@
-(use fann octave)
+(use (prefix fann fann:) octave)
 (octave:start)
 
 ;; eg 4 -> '(0 0 0 0 1 0 0 0 0 0)


### PR DESCRIPTION
Note that I haven't tested sample-mini-ocr because of the octave dependency, so it may need other fixes besides this. I have tested the other samples.